### PR TITLE
changing empty to blank to make API more robust

### DIFF
--- a/lib/aftership/v4/tracking.rb
+++ b/lib/aftership/v4/tracking.rb
@@ -6,7 +6,7 @@ module AfterShip
 
 			#POST /trackings
 			def self.create(tracking_number, params = {})
-				if tracking_number.empty?
+				if tracking_number.blank?
 					raise ArgumentError.new('tracking_number is required.')
 				else
 					query_hash = {:tracking_number => tracking_number}
@@ -18,7 +18,7 @@ module AfterShip
 
 			#POST /trackings/:slug/:tracking_number/retrack
 			def self.retrack(slug, tracking_number)
-				if slug.empty? || tracking_number.empty?
+				if slug.blank? || tracking_number.blank?
 					raise ArgumentError.new('slug and tracking_number are required.')
 				end
 				new(:post, "trackings/#{slug}/#{tracking_number}/retrack").call
@@ -26,7 +26,7 @@ module AfterShip
 
 			#DELETE /trackings/:slug/:tracking_number
 			def self.delete(slug, tracking_number)
-				if slug.empty? || tracking_number.empty?
+				if slug.blank? || tracking_number.blank?
 					raise ArgumentError.new('slug and tracking_number are required.')
 				end
 				new(:delete, "trackings/#{slug}/#{tracking_number}").call
@@ -34,7 +34,7 @@ module AfterShip
 
 			#GET /trackings/:slug/:tracking_number
 			def self.get(slug, tracking_number, params = {})
-				if slug.empty? || tracking_number.empty?
+				if slug.blank? || tracking_number.blank?
 					raise ArgumentError.new('slug and tracking_number are required.')
 				end
 				new(:get, "trackings/#{slug}/#{tracking_number}", params).call
@@ -42,7 +42,7 @@ module AfterShip
 
 			#GET /trackings/:id
 			def self.get_by_id(id, params = {})
-				if id.empty?
+				if id.blank?
 					raise ArgumentError.new('id is required.')
 				end
 				new(:get, "trackings/#{id}", params).call
@@ -55,7 +55,7 @@ module AfterShip
 
 			#PUT /trackings/:slug/:tracking_number
 			def self.update(slug, tracking_number, params = {})
-				if slug.empty? || tracking_number.empty?
+				if slug.blank? || tracking_number.blank?
 					raise ArgumentError.new('slug and tracking_number are required.')
 				end
 				body = {:tracking => params}


### PR DESCRIPTION
checking if parameter is "empty?" on nil will raise exception, when "blank" will return true and raise the intended exception ( e.g. "raise ArgumentError").